### PR TITLE
Fix Centos install docs

### DIFF
--- a/content/riak/kv/2.2.5/setup/installing/rhel-centos.md
+++ b/content/riak/kv/2.2.5/setup/installing/rhel-centos.md
@@ -108,14 +108,7 @@ instructions.
 
 ### For Centos 5 / RHEL 5
 
-You can install CentOS 5/RHEL 5 using yum, which we recommend:
-
-```bash
-sudo yum install http://yum.basho.com/gpg/basho-release-5-1.noarch.rpm
-sudo yum install riak
-```
-
-Or you can install the `.rpm` package manually:
+You can install the `.rpm` package manually:
 
 ```bash
 wget https://files.tiot.jp/riak/kv/2.2/2.2.5/rhel/5/riak-2.2.5-1.el5.x86_64.rpm
@@ -124,14 +117,7 @@ sudo rpm -Uvh riak-2.2.5-1.el5.x86_64.rpm
 
 ### For Centos 6 / RHEL 6
 
-You can install using yum, which we recommend:
-
-```bash
-sudo yum install http://yum.basho.com/gpg/basho-release-6-1.noarch.rpm
-sudo yum install riak
-```
-
-Or you can install the `.rpm` package manually:
+You can install the `.rpm` package manually:
 
 ```bash
 wget https://files.tiot.jp/riak/kv/2.2/2.2.5/rhel/6/riak-2.2.5-1.el6.x86_64.rpm

--- a/content/riak/kv/2.2.5/setup/installing/rhel-centos.md
+++ b/content/riak/kv/2.2.5/setup/installing/rhel-centos.md
@@ -26,7 +26,7 @@ aliases:
 
 Riak KV can be installed on CentOS- or Red-Hat-based systems using a binary
 package or by [compiling Riak from source code][install source index]. The following steps have been tested to work with Riak on
-CentOS/RHEL 5.10, 6.5, and 7.0.1406.
+CentOS/RHEL 6.5 and 7.0.1406.
 
 > **Note on SELinux**
 >
@@ -45,14 +45,14 @@ docs](https://packagecloud.io/basho/riak/install).
 
 Platform-specific pages are linked below:
 
-* [el5](https://packagecloud.io/basho/riak/packages/el/5/riak-2.2.5-1.x86_64.rpm)
-* [el6](https://packagecloud.io/basho/riak/packages/el/6/riak-2.2.5-1.el6.x86_64.rpm)
-* [el7](https://packagecloud.io/basho/riak/packages/el/7/riak-2.2.5-1.el7.centos.x86_64.rpm)
-* [Fedora 19](https://packagecloud.io/basho/riak/packages/fedora/19/riak-2.2.5-1.fc19.x86_64.rpm)
+* [el6](https://files.tiot.jp/riak/packages/el/6/riak-2.2.5-1.el6.x86_64.rpm)
+* [el7](https://files.tiot.jp/riak/packages/el/7/riak-2.2.5-1.el7.centos.x86_64.rpm)
+* [Fedora 19](https://files.tiot.jp/riak/packages/fedora/19/riak-2.2.5-1.fc19.x86_64.rpm)
 
 Our documentation also includes instructions regarding signing keys and
 sources lists, which can be found in the section immediately below.
 
+<!---
 ## Advanced rpm Installation
 
 For the simplest installation process on LTS (Long-Term Support)
@@ -100,19 +100,20 @@ sslcacert=/etc/pki/tls/certs/ca-bundle.crt
 
 With your `basho.repo` file population, you can update your rpm sources
 list.
+-->
 
 ## Installing From Package
 
 If you wish to install the RHEL/CentOS packages by hand, follow these
 instructions.
 
-### For Centos 5 / RHEL 5
+### For Centos 7 / RHEL 7
 
 You can install the `.rpm` package manually:
 
 ```bash
-wget https://files.tiot.jp/riak/kv/2.2/2.2.5/rhel/5/riak-2.2.5-1.el5.x86_64.rpm
-sudo rpm -Uvh riak-2.2.5-1.el5.x86_64.rpm
+wget https://files.tiot.jp/riak/kv/2.2/2.2.5/rhel/7/riak-2.2.5-1.el7.centos.x86_64.rpm
+sudo rpm -Uvh riak-2.2.5-1.el7.centos.x86_64.rpm
 ```
 
 ### For Centos 6 / RHEL 6

--- a/content/riak/kv/2.2.5/setup/installing/rhel-centos.md
+++ b/content/riak/kv/2.2.5/setup/installing/rhel-centos.md
@@ -49,10 +49,10 @@ Platform-specific pages are linked below:
 * [el7](https://files.tiot.jp/riak/packages/el/7/riak-2.2.5-1.el7.centos.x86_64.rpm)
 * [Fedora 19](https://files.tiot.jp/riak/packages/fedora/19/riak-2.2.5-1.fc19.x86_64.rpm)
 
+<!---
 Our documentation also includes instructions regarding signing keys and
 sources lists, which can be found in the section immediately below.
 
-<!---
 ## Advanced rpm Installation
 
 For the simplest installation process on LTS (Long-Term Support)


### PR DESCRIPTION
Cleaned up the doc. 

* Removed v5
* Fixed URLs: packagecloud.io -> files.tiot.jp
* Removed the old `yum install` instructions against the ancient yum.basho.com
* Commented out current yum repo installation, because basho's yum repo at packagecloud.io won't have 2.2.5+