### PR TITLE
Make the leveled description render as a list

### DIFF
--- a/content/riak/kv/2.9.0p5/setup/planning/backend/leveled.md
+++ b/content/riak/kv/2.9.0p5/setup/planning/backend/leveled.md
@@ -29,6 +29,7 @@ aliases:
 [config reference#aae]: {{<baseurl>}}riak/kv/2.9.0p5/configuring/reference/#active-anti-entropy
 
 [Leveled](https://github.com/martinsumner/leveled) is a simple Key-Value store based on the concept of Log-Structured Merge Trees, with the following characteristics:
+
 - Optimised for workloads with larger values (e.g. > 4KB).
 - Explicitly supports HEAD requests in addition to GET requests:
 - Splits the storage of value between keys/metadata and body (assuming some definition of metadata is provided);

--- a/content/riak/kv/2.9.1/setup/planning/backend/leveled.md
+++ b/content/riak/kv/2.9.1/setup/planning/backend/leveled.md
@@ -23,6 +23,7 @@ aliases:
 [leveled](https://github.com/martinsumner/leveled)
 
 Leveled is a simple Key-Value store based on the concept of Log-Structured Merge Trees, with the following characteristics:
+
 - Optimised for workloads with larger values (e.g. > 4KB).
 - Explicitly supports HEAD requests in addition to GET requests:
 - Splits the storage of value between keys/metadata and body (assuming some definition of metadata is provided);

--- a/content/riak/kv/2.9.10/setup/planning/backend/leveled.md
+++ b/content/riak/kv/2.9.10/setup/planning/backend/leveled.md
@@ -26,6 +26,7 @@ aliases:
 [leveled](https://github.com/martinsumner/leveled)
 
 Leveled is a simple Key-Value store based on the concept of Log-Structured Merge Trees, with the following characteristics:
+
 - Optimised for workloads with larger values (e.g. > 4KB).
 - Explicitly supports HEAD requests in addition to GET requests:
 - Splits the storage of value between keys/metadata and body (assuming some definition of metadata is provided);

--- a/content/riak/kv/2.9.2/setup/planning/backend/leveled.md
+++ b/content/riak/kv/2.9.2/setup/planning/backend/leveled.md
@@ -23,6 +23,7 @@ aliases:
 [leveled](https://github.com/martinsumner/leveled)
 
 Leveled is a simple Key-Value store based on the concept of Log-Structured Merge Trees, with the following characteristics:
+
 - Optimised for workloads with larger values (e.g. > 4KB).
 - Explicitly supports HEAD requests in addition to GET requests:
 - Splits the storage of value between keys/metadata and body (assuming some definition of metadata is provided);

--- a/content/riak/kv/2.9.4/setup/planning/backend/leveled.md
+++ b/content/riak/kv/2.9.4/setup/planning/backend/leveled.md
@@ -23,6 +23,7 @@ aliases:
 [leveled](https://github.com/martinsumner/leveled)
 
 Leveled is a simple Key-Value store based on the concept of Log-Structured Merge Trees, with the following characteristics:
+
 - Optimised for workloads with larger values (e.g. > 4KB).
 - Explicitly supports HEAD requests in addition to GET requests:
 - Splits the storage of value between keys/metadata and body (assuming some definition of metadata is provided);

--- a/content/riak/kv/2.9.7/setup/planning/backend/leveled.md
+++ b/content/riak/kv/2.9.7/setup/planning/backend/leveled.md
@@ -23,6 +23,7 @@ aliases:
 [leveled](https://github.com/martinsumner/leveled)
 
 Leveled is a simple Key-Value store based on the concept of Log-Structured Merge Trees, with the following characteristics:
+
 - Optimised for workloads with larger values (e.g. > 4KB).
 - Explicitly supports HEAD requests in addition to GET requests:
 - Splits the storage of value between keys/metadata and body (assuming some definition of metadata is provided);

--- a/content/riak/kv/2.9.8/setup/planning/backend/leveled.md
+++ b/content/riak/kv/2.9.8/setup/planning/backend/leveled.md
@@ -23,6 +23,7 @@ aliases:
 [leveled](https://github.com/martinsumner/leveled)
 
 Leveled is a simple Key-Value store based on the concept of Log-Structured Merge Trees, with the following characteristics:
+
 - Optimised for workloads with larger values (e.g. > 4KB).
 - Explicitly supports HEAD requests in addition to GET requests:
 - Splits the storage of value between keys/metadata and body (assuming some definition of metadata is provided);

--- a/content/riak/kv/2.9.9/setup/planning/backend/leveled.md
+++ b/content/riak/kv/2.9.9/setup/planning/backend/leveled.md
@@ -23,6 +23,7 @@ aliases:
 [leveled](https://github.com/martinsumner/leveled)
 
 Leveled is a simple Key-Value store based on the concept of Log-Structured Merge Trees, with the following characteristics:
+
 - Optimised for workloads with larger values (e.g. > 4KB).
 - Explicitly supports HEAD requests in addition to GET requests:
 - Splits the storage of value between keys/metadata and body (assuming some definition of metadata is provided);


### PR DESCRIPTION
The leveled markdown didn't have a blank line before the beginning of the list causing the list to render as a paragraph full of hyphens.
