### PR TITLE
Pretty OS version names and configurable Contact Us

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -141,6 +141,11 @@ params:
       releases:
         - ["1.0.0"]
       latest: "1.0.0"
+
+# The link to use for Contact Us in the menu and the banner
+contact_us_url: "https://www.tiot.jp/en/about-us/contact-us/"
+
+
 ---
 
 

--- a/data/os_metadata.yaml
+++ b/data/os_metadata.yaml
@@ -55,6 +55,13 @@ ubuntu:
   title: "Ubuntu"
   image_src: "images/shared/operating_system_branding/ubuntu.png"
   installing_instructions_page: "debian-ubuntu/"
+  versions:
+    precise64: "Precise Pangolin (12.04)"
+    trusty64: "Trusty Tahr (14.04)"
+    xenial64: "Xenial Xerus (16.04)"
+    bionic64: "Bionic Beaver (18.04)"
+    focal64: "Focal Fossa (20.04)"
+    jammy64: "Jammy Jellyfish (22.04)"
 source:
   image_src: "images/shared/operating_system_branding/targz.png"
   installing_instructions_page: "source/"

--- a/fake.txt
+++ b/fake.txt
@@ -1,3 +1,0 @@
-
-Something
-

--- a/layouts/_default/downloads.html
+++ b/layouts/_default/downloads.html
@@ -102,7 +102,13 @@
 
             <tr class="downloads__version-title">
               <td colspan="3">
-                {{/*<h4/>*/}}{{ printf "#### %s %s" $os_title $version_map.version | markdownify }}
+                {{ if $os_data.versions }}
+                  {{ $version_raw        := (printf "%s" $version_map.version )           }}
+                  {{ $version_title        := (index $os_data.versions $version_raw ) | default $version_raw           }}
+                  {{/*<h4/>*/}}{{ printf "#### %s %s" $os_title $version_title | markdownify }}
+                {{ else }}
+                  {{/*<h4/>*/}}{{ printf "#### %s %s" $os_title $version_map.version | markdownify }}
+                {{ end }}
               </td>
             </tr>
 

--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -49,7 +49,7 @@
       <div class="float-right">
         <!-- Comment out the newlines s.t. whitespace isn't rendered in-between inline-block elements. --><!--
      --><a class="inline-block   banner__brand-link" href="{{ .Site.BaseURL }}community">Community</a><!--
-     --><a class="inline-block   banner__brand-link" href="https://www.tiot.jp/en/about-us/contact-us/">Contact</a><!--
+     --><a class="inline-block   banner__brand-link" href="{{ .Site.Params.contact_us_url }}">Contact</a><!--
    --></div>
     </div>
     </div>

--- a/layouts/partials/content-navigation.html
+++ b/layouts/partials/content-navigation.html
@@ -175,7 +175,7 @@
 
             <span class="block float-left   content-menu__icon-container   docs-icon--question-sign">|</span>
 
-            <a class="block overflow" href="https://www.tiot.jp/en/about-us/contact-us/">
+            <a class="block overflow" href="{{ .Site.Params.contact_us_url }}">
               <span class="block   content-menu__item__right-border">
                 <sub>Need to chat?</sub><br>
                 <strong>Contact us directly</strong>


### PR DESCRIPTION
- Pretty OS version names taken from `data/os_metadata.yaml`
- Configurable Contact Us URI in `config.yaml`
- Removed `fake.txt` used for the HEAD reset in `master`