### PR TITLE
Curl examples from 2.2.6 that were lost

### DIFF
--- a/content/riak/kv/2.9.0p5/developing/usage/updating-objects.md
+++ b/content/riak/kv/2.9.0p5/developing/usage/updating-objects.md
@@ -222,6 +222,11 @@ X-Riak-Vclock: a85hYGBgzGDKBVIcWu/1S4OVPaIymBIZ81gZbskuOMOXBQA=
 
 # When performing a write to the same key, that same header needs to
 # accompany the write for Riak to be able to use the context object
+
+curl -XPUT \
+  -H "X-Riak-Vclock: a85hYGBgzGDKBVIcWu/1S4OVPaIymBIZ81gZbskuOMOXBQA=" \
+  -d "Harlem Globetrotters" \
+  http://localhost:8098/types/sports/buckets/nba/keys/champion
 ```
 
 In the samples above, we didn't need to actually interact with the
@@ -299,6 +304,15 @@ fmt.Println(rsp.VClock)
 
 // Output:
 // X3hNXFq3ythUqvvrG9eJEGbUyLS
+```
+```curl
+# When using curl, the context object is attached to the X-Riak-Vclock header
+
+curl -i http://localhost:8098/types/sports/buckets/nba/keys/champion
+
+# In the resulting output, the header will look something like this:
+
+X-Riak-Vclock: a85hYGBgzGDKBVIcWu/1S4OVPaIymBIZ81gZbskuOMOXBQA=
 ```
 
 ## The Object Update Cycle
@@ -474,6 +488,14 @@ if err := cluster.Execute(cmd); err != nil {
 fmt.Println("Stored Pete Carroll")
 ```
 
+```curl
+
+curl -XPUT \
+  -H "Content-Type: text/plain" \
+  -d "Pete Carroll" \
+  http://localhost:8098/types/siblings/buckets/coaches/keys/seahawks
+```
+
 Every once in a while, though, head coaches change in the NFL, which
 means that our data would need to be updated. Below is an example
 function for updating such objects:
@@ -618,6 +640,26 @@ func updateCoach(cluster *riak.Cluster, team, newCoach string) error {
 
     return nil
 }
+```
+
+```curl
+
+# When using curl, the context object is attached to the X-Riak-Vclock header
+
+curl -i http://localhost:8098/types/siblings/buckets/coaches/keys/packers
+
+# In the resulting output, the header will look something like this:
+
+X-Riak-Vclock: a85hYGBgzGDKBVIcWu/1S4OVPaIymBIZ81gZbskuOMOXBQA=
+
+# When performing a write to the same key, that same header needs to
+# accompany the write for Riak to be able to use the context object
+
+curl -XPUT \
+  -H "Content-Type: text/plain" \
+  -H "X-Riak-Vclock: a85hYGBgzGDKBVIcWu/1S4OVPaIymBIZ81gZbskuOMOXBQA=" \
+  -d "Vince Lombardi" \
+  http://localhost:8098/types/siblings/buckets/coaches/keys/packers
 ```
 
 In the example above, you can see the three steps in action: first, the


### PR DESCRIPTION
Curl examples from 2.2.6 that were lost

1 updates curl example, and 3 new ones.

So far in 2.9.0p5, needs to be added to:
- 2.9.1
- 2.9.2
- 2.9.4
- 2.9.7
- 2.9.8
- 2.9.9
- 2.9.10
- 3.0.1
- 3.0.2
- 3.0.3
- 3.0.4
- 3.0.6
- 3.0.7
- 3.0.8
- 3.0.9
- 3.0.10 (when ready)