### PR TITLE
Updated Alpine Linux instuctions

### DIFF
--- a/content/riak/kv/3.0.10/setup/installing/alpine-linux.md
+++ b/content/riak/kv/3.0.10/setup/installing/alpine-linux.md
@@ -30,7 +30,8 @@ package from the Riak repository.
 
 The following steps have been tested to work with Riak KV on:
 
-* Alpine Linux 3.16
+* Alpine Linux 3.16 using x86_64
+* Alpine Linux 3.16 using aarch64
 
 ## Riak 64-bit Installation
 

--- a/content/riak/kv/3.0.10/setup/installing/alpine-linux.md
+++ b/content/riak/kv/3.0.10/setup/installing/alpine-linux.md
@@ -30,7 +30,7 @@ package from the Riak repository.
 
 The following steps have been tested to work with Riak KV on:
 
-* Alpine Linux 3.14
+* Alpine Linux 3.16
 
 ## Riak 64-bit Installation
 
@@ -44,7 +44,7 @@ To install Riak on Alpine Linux:
    * Run `apk update`
 4. Install Riak:
    * For the latest version, run `apk add riak`
-   * For a specific version, run `apk add riak=3.0.10.0-r0`
+   * For a specific version, run `apk add riak=3.0.10.0-r1`
 
 ## Next Steps
 

--- a/content/riak/kv/3.0.11/setup/installing/alpine-linux.md
+++ b/content/riak/kv/3.0.11/setup/installing/alpine-linux.md
@@ -30,7 +30,8 @@ package from the Riak repository.
 
 The following steps have been tested to work with Riak KV on:
 
-* Alpine Linux 3.16
+* Alpine Linux 3.16 using x86_64
+* Alpine Linux 3.16 using aarch64
 
 ## Riak 64-bit Installation
 

--- a/content/riak/kv/3.0.11/setup/installing/alpine-linux.md
+++ b/content/riak/kv/3.0.11/setup/installing/alpine-linux.md
@@ -30,7 +30,7 @@ package from the Riak repository.
 
 The following steps have been tested to work with Riak KV on:
 
-* Alpine Linux 3.14
+* Alpine Linux 3.16
 
 ## Riak 64-bit Installation
 
@@ -44,7 +44,7 @@ To install Riak on Alpine Linux:
    * Run `apk update`
 4. Install Riak:
    * For the latest version, run `apk add riak`
-   * For a specific version, run `apk add riak=3.0.11.0-r0`
+   * For a specific version, run `apk add riak=3.0.11.0-r1`
 
 ## Next Steps
 

--- a/content/riak/kv/3.0.11/setup/installing/alpine-linux.md
+++ b/content/riak/kv/3.0.11/setup/installing/alpine-linux.md
@@ -15,10 +15,10 @@ version_history:
   in: "3.0.9+"
 toc: true
 aliases:
-  - /riak/3.0.10/ops/building/installing/installing-on-alpine-linux
-  - /riak/kv/3.0.10/ops/building/installing/installing-on-alpine-linux
-  - /riak/3.0.10/installing/alpine-linux/
-  - /riak/kv/3.0.10/installing/alpine-linux/
+  - /riak/3.0.11/ops/building/installing/installing-on-alpine-linux
+  - /riak/kv/3.0.11/ops/building/installing/installing-on-alpine-linux
+  - /riak/3.0.11/installing/alpine-linux/
+  - /riak/kv/3.0.11/installing/alpine-linux/
 ---
 
 [security index]: {{<baseurl>}}riak/kv/3.0.10/using/security/

--- a/content/riak/kv/3.0.11/setup/installing/alpine-linux.md
+++ b/content/riak/kv/3.0.11/setup/installing/alpine-linux.md
@@ -21,9 +21,9 @@ aliases:
   - /riak/kv/3.0.11/installing/alpine-linux/
 ---
 
-[security index]: {{<baseurl>}}riak/kv/3.0.10/using/security/
-[install source erlang]: {{<baseurl>}}riak/kv/3.0.10/setup/installing/source/erlang
-[install verify]: {{<baseurl>}}riak/kv/3.0.10/setup/installing/verify
+[security index]: {{<baseurl>}}riak/kv/3.0.11/using/security/
+[install source erlang]: {{<baseurl>}}riak/kv/3.0.11/setup/installing/source/erlang
+[install verify]: {{<baseurl>}}riak/kv/3.0.11/setup/installing/verify
 
 Riak KV can be installed on Alpine Linux using a binary
 package from the Riak repository.

--- a/content/riak/kv/3.0.12/setup/installing/alpine-linux.md
+++ b/content/riak/kv/3.0.12/setup/installing/alpine-linux.md
@@ -30,7 +30,8 @@ package from the Riak repository.
 
 The following steps have been tested to work with Riak KV on:
 
-* Alpine Linux 3.16
+* Alpine Linux 3.16 using x86_64
+* Alpine Linux 3.16 using aarch64
 
 ## Riak 64-bit Installation
 

--- a/content/riak/kv/3.0.12/setup/installing/alpine-linux.md
+++ b/content/riak/kv/3.0.12/setup/installing/alpine-linux.md
@@ -1,0 +1,51 @@
+﻿---
+title_supertext: "Installing on"
+title: "Alpine Linux"
+description: "installing Riak on Alpine Linux"
+project: "riak_kv"
+project_version: 3.0.12
+menu:
+  riak_kv-3.0.12:
+    name: "Alpine Linux"
+    identifier: "installing_alpine_linux"
+    weight: 301
+    parent: "installing"
+since: 3.0.9
+version_history:
+  in: "3.0.9+"
+toc: true
+aliases:
+  - /riak/3.0.12/ops/building/installing/installing-on-alpine-linux
+  - /riak/kv/3.0.12/ops/building/installing/installing-on-alpine-linux
+  - /riak/3.0.12/installing/alpine-linux/
+  - /riak/kv/3.0.12/installing/alpine-linux/
+---
+
+[security index]: {{<baseurl>}}riak/kv/3.0.10/using/security/
+[install source erlang]: {{<baseurl>}}riak/kv/3.0.10/setup/installing/source/erlang
+[install verify]: {{<baseurl>}}riak/kv/3.0.10/setup/installing/verify
+
+Riak KV can be installed on Alpine Linux using a binary
+package from the Riak repository.
+
+The following steps have been tested to work with Riak KV on:
+
+* Alpine Linux 3.16
+
+## Riak 64-bit Installation
+
+To install Riak on Alpine Linux:
+
+1. Add the Riak repository:
+   * Run `echo https://files.tiot.jp/alpine/v3.16/main >> /etc/apk/repositories`
+2. Download and install the Riak repository public key:
+   * Run `wget http://files.tiot.jp/alpine/alpine@tiot.jp.rsa.pub -O /etc/apk/keys/alpine@tiot.jp.rsa.pub`
+3. Update your list of packages:
+   * Run `apk update`
+4. Install Riak:
+   * For the latest version, run `apk add riak`
+   * For a specific version, run `apk add riak=3.0.12.0-r0`
+
+## Next Steps
+
+Now that Riak is installed, check out [Verifying a Riak Installation][install verify].

--- a/content/riak/kv/3.0.12/setup/installing/alpine-linux.md
+++ b/content/riak/kv/3.0.12/setup/installing/alpine-linux.md
@@ -21,9 +21,9 @@ aliases:
   - /riak/kv/3.0.12/installing/alpine-linux/
 ---
 
-[security index]: {{<baseurl>}}riak/kv/3.0.10/using/security/
-[install source erlang]: {{<baseurl>}}riak/kv/3.0.10/setup/installing/source/erlang
-[install verify]: {{<baseurl>}}riak/kv/3.0.10/setup/installing/verify
+[security index]: {{<baseurl>}}riak/kv/3.0.12/using/security/
+[install source erlang]: {{<baseurl>}}riak/kv/3.0.12/setup/installing/source/erlang
+[install verify]: {{<baseurl>}}riak/kv/3.0.12/setup/installing/verify
 
 Riak KV can be installed on Alpine Linux using a binary
 package from the Riak repository.

--- a/content/riak/kv/3.0.13/setup/installing/alpine-linux.md
+++ b/content/riak/kv/3.0.13/setup/installing/alpine-linux.md
@@ -30,7 +30,8 @@ package from the Riak repository.
 
 The following steps have been tested to work with Riak KV on:
 
-* Alpine Linux 3.16
+* Alpine Linux 3.16 using x86_64
+* Alpine Linux 3.16 using aarch64
 
 ## Riak 64-bit Installation
 

--- a/content/riak/kv/3.0.13/setup/installing/alpine-linux.md
+++ b/content/riak/kv/3.0.13/setup/installing/alpine-linux.md
@@ -1,0 +1,51 @@
+﻿---
+title_supertext: "Installing on"
+title: "Alpine Linux"
+description: "installing Riak on Alpine Linux"
+project: "riak_kv"
+project_version: 3.0.13
+menu:
+  riak_kv-3.0.13:
+    name: "Alpine Linux"
+    identifier: "installing_alpine_linux"
+    weight: 301
+    parent: "installing"
+since: 3.0.9
+version_history:
+  in: "3.0.9+"
+toc: true
+aliases:
+  - /riak/3.0.13/ops/building/installing/installing-on-alpine-linux
+  - /riak/kv/3.0.13/ops/building/installing/installing-on-alpine-linux
+  - /riak/3.0.13/installing/alpine-linux/
+  - /riak/kv/3.0.13/installing/alpine-linux/
+---
+
+[security index]: {{<baseurl>}}riak/kv/3.0.13/using/security/
+[install source erlang]: {{<baseurl>}}riak/kv/3.0.13/setup/installing/source/erlang
+[install verify]: {{<baseurl>}}riak/kv/3.0.13/setup/installing/verify
+
+Riak KV can be installed on Alpine Linux using a binary
+package from the Riak repository.
+
+The following steps have been tested to work with Riak KV on:
+
+* Alpine Linux 3.16
+
+## Riak 64-bit Installation
+
+To install Riak on Alpine Linux:
+
+1. Add the Riak repository:
+   * Run `echo https://files.tiot.jp/alpine/v3.16/main >> /etc/apk/repositories`
+2. Download and install the Riak repository public key:
+   * Run `wget http://files.tiot.jp/alpine/alpine@tiot.jp.rsa.pub -O /etc/apk/keys/alpine@tiot.jp.rsa.pub`
+3. Update your list of packages:
+   * Run `apk update`
+4. Install Riak:
+   * For the latest version, run `apk add riak`
+   * For a specific version, run `apk add riak=3.0.13.0-r0`
+
+## Next Steps
+
+Now that Riak is installed, check out [Verifying a Riak Installation][install verify].

--- a/content/riak/kv/3.0.14/setup/installing/alpine-linux.md
+++ b/content/riak/kv/3.0.14/setup/installing/alpine-linux.md
@@ -30,7 +30,8 @@ package from the Riak repository.
 
 The following steps have been tested to work with Riak KV on:
 
-* Alpine Linux 3.16
+* Alpine Linux 3.16 using x86_64
+* Alpine Linux 3.16 using aarch64
 
 ## Riak 64-bit Installation
 

--- a/content/riak/kv/3.0.14/setup/installing/alpine-linux.md
+++ b/content/riak/kv/3.0.14/setup/installing/alpine-linux.md
@@ -1,0 +1,51 @@
+﻿---
+title_supertext: "Installing on"
+title: "Alpine Linux"
+description: "installing Riak on Alpine Linux"
+project: "riak_kv"
+project_version: 3.0.14
+menu:
+  riak_kv-3.0.14:
+    name: "Alpine Linux"
+    identifier: "installing_alpine_linux"
+    weight: 301
+    parent: "installing"
+since: 3.0.9
+version_history:
+  in: "3.0.9+"
+toc: true
+aliases:
+  - /riak/3.0.14/ops/building/installing/installing-on-alpine-linux
+  - /riak/kv/3.0.14/ops/building/installing/installing-on-alpine-linux
+  - /riak/3.0.14/installing/alpine-linux/
+  - /riak/kv/3.0.14/installing/alpine-linux/
+---
+
+[security index]: {{<baseurl>}}riak/kv/3.0.14/using/security/
+[install source erlang]: {{<baseurl>}}riak/kv/3.0.14/setup/installing/source/erlang
+[install verify]: {{<baseurl>}}riak/kv/3.0.14/setup/installing/verify
+
+Riak KV can be installed on Alpine Linux using a binary
+package from the Riak repository.
+
+The following steps have been tested to work with Riak KV on:
+
+* Alpine Linux 3.16
+
+## Riak 64-bit Installation
+
+To install Riak on Alpine Linux:
+
+1. Add the Riak repository:
+   * Run `echo https://files.tiot.jp/alpine/v3.16/main >> /etc/apk/repositories`
+2. Download and install the Riak repository public key:
+   * Run `wget http://files.tiot.jp/alpine/alpine@tiot.jp.rsa.pub -O /etc/apk/keys/alpine@tiot.jp.rsa.pub`
+3. Update your list of packages:
+   * Run `apk update`
+4. Install Riak:
+   * For the latest version, run `apk add riak`
+   * For a specific version, run `apk add riak=3.0.14.0-r0`
+
+## Next Steps
+
+Now that Riak is installed, check out [Verifying a Riak Installation][install verify].

--- a/content/riak/kv/3.0.15/setup/installing/alpine-linux.md
+++ b/content/riak/kv/3.0.15/setup/installing/alpine-linux.md
@@ -1,0 +1,52 @@
+﻿---
+title_supertext: "Installing on"
+title: "Alpine Linux"
+description: "installing Riak on Alpine Linux"
+project: "riak_kv"
+project_version: 3.0.15
+menu:
+  riak_kv-3.0.15:
+    name: "Alpine Linux"
+    identifier: "installing_alpine_linux"
+    weight: 301
+    parent: "installing"
+since: 3.0.9
+version_history:
+  in: "3.0.9+"
+toc: true
+aliases:
+  - /riak/3.0.15/ops/building/installing/installing-on-alpine-linux
+  - /riak/kv/3.0.15/ops/building/installing/installing-on-alpine-linux
+  - /riak/3.0.15/installing/alpine-linux/
+  - /riak/kv/3.0.15/installing/alpine-linux/
+---
+
+[security index]: {{<baseurl>}}riak/kv/3.0.15/using/security/
+[install source erlang]: {{<baseurl>}}riak/kv/3.0.15/setup/installing/source/erlang
+[install verify]: {{<baseurl>}}riak/kv/3.0.15/setup/installing/verify
+
+Riak KV can be installed on Alpine Linux using a binary
+package from the Riak repository.
+
+The following steps have been tested to work with Riak KV on:
+
+* Alpine Linux 3.16
+* Alpine Linux 3.18
+
+## Riak 64-bit Installation
+
+To install Riak on Alpine Linux:
+
+1. Add the Riak repository:
+   * Run `echo https://files.tiot.jp/alpine/v3.16/main >> /etc/apk/repositories`
+2. Download and install the Riak repository public key:
+   * Run `wget http://files.tiot.jp/alpine/alpine@tiot.jp.rsa.pub -O /etc/apk/keys/alpine@tiot.jp.rsa.pub`
+3. Update your list of packages:
+   * Run `apk update`
+4. Install Riak:
+   * For the latest version, run `apk add riak`
+   * For a specific version, run `apk add riak=3.0.15.0-r0`
+
+## Next Steps
+
+Now that Riak is installed, check out [Verifying a Riak Installation][install verify].

--- a/content/riak/kv/3.0.15/setup/installing/alpine-linux.md
+++ b/content/riak/kv/3.0.15/setup/installing/alpine-linux.md
@@ -30,8 +30,10 @@ package from the Riak repository.
 
 The following steps have been tested to work with Riak KV on:
 
-* Alpine Linux 3.16
-* Alpine Linux 3.18
+* Alpine Linux 3.16 using x86_64
+* Alpine Linux 3.16 using aarch64
+* Alpine Linux 3.18 using x86_64
+* Alpine Linux 3.18 using aarch64
 
 ## Riak 64-bit Installation
 

--- a/content/riak/kv/3.0.16/setup/installing/alpine-linux.md
+++ b/content/riak/kv/3.0.16/setup/installing/alpine-linux.md
@@ -30,7 +30,8 @@ package from the Riak repository.
 
 The following steps have been tested to work with Riak KV on:
 
-* Alpine Linux 3.18
+* Alpine Linux 3.18 using x86_64
+* Alpine Linux 3.18 using aarch64
 
 ## Riak 64-bit Installation
 

--- a/content/riak/kv/3.0.16/setup/installing/alpine-linux.md
+++ b/content/riak/kv/3.0.16/setup/installing/alpine-linux.md
@@ -1,0 +1,51 @@
+﻿---
+title_supertext: "Installing on"
+title: "Alpine Linux"
+description: "installing Riak on Alpine Linux"
+project: "riak_kv"
+project_version: 3.0.16
+menu:
+  riak_kv-3.0.16:
+    name: "Alpine Linux"
+    identifier: "installing_alpine_linux"
+    weight: 301
+    parent: "installing"
+since: 3.0.9
+version_history:
+  in: "3.0.9+"
+toc: true
+aliases:
+  - /riak/3.0.16/ops/building/installing/installing-on-alpine-linux
+  - /riak/kv/3.0.16/ops/building/installing/installing-on-alpine-linux
+  - /riak/3.0.16/installing/alpine-linux/
+  - /riak/kv/3.0.16/installing/alpine-linux/
+---
+
+[security index]: {{<baseurl>}}riak/kv/3.0.16/using/security/
+[install source erlang]: {{<baseurl>}}riak/kv/3.0.16/setup/installing/source/erlang
+[install verify]: {{<baseurl>}}riak/kv/3.0.16/setup/installing/verify
+
+Riak KV can be installed on Alpine Linux using a binary
+package from the Riak repository.
+
+The following steps have been tested to work with Riak KV on:
+
+* Alpine Linux 3.18
+
+## Riak 64-bit Installation
+
+To install Riak on Alpine Linux:
+
+1. Add the Riak repository:
+   * Run `echo https://files.tiot.jp/alpine/v3.16/main >> /etc/apk/repositories`
+2. Download and install the Riak repository public key:
+   * Run `wget http://files.tiot.jp/alpine/alpine@tiot.jp.rsa.pub -O /etc/apk/keys/alpine@tiot.jp.rsa.pub`
+3. Update your list of packages:
+   * Run `apk update`
+4. Install Riak:
+   * For the latest version, run `apk add riak`
+   * For a specific version, run `apk add riak=3.0.16.0-r0`
+
+## Next Steps
+
+Now that Riak is installed, check out [Verifying a Riak Installation][install verify].

--- a/content/riak/kv/3.0.9/setup/installing/alpine-linux.md
+++ b/content/riak/kv/3.0.9/setup/installing/alpine-linux.md
@@ -30,7 +30,8 @@ package from the Riak repository.
 
 The following steps have been tested to work with Riak KV on:
 
-* Alpine Linux 3.16
+* Alpine Linux 3.16 using x86_64
+* Alpine Linux 3.16 using aarch64
 
 ## Riak 64-bit Installation
 

--- a/content/riak/kv/3.0.9/setup/installing/alpine-linux.md
+++ b/content/riak/kv/3.0.9/setup/installing/alpine-linux.md
@@ -41,7 +41,8 @@ To install Riak on Alpine Linux:
 2. Update your list of packages:
    * Run `apk update`
 3. Install Riak:
-   * Run `apk add riak`
+   * For the latest version, run `apk add riak`
+   * For a specific version, run `apk add riak=3.0.9.0-r1`
 
 ## Next Steps
 

--- a/content/riak/kv/3.0.9/setup/installing/alpine-linux.md
+++ b/content/riak/kv/3.0.9/setup/installing/alpine-linux.md
@@ -30,7 +30,7 @@ package from the Riak repository.
 
 The following steps have been tested to work with Riak KV on:
 
-* Alpine Linux 3.14
+* Alpine Linux 3.16
 
 ## Riak 64-bit Installation
 

--- a/content/riak/kv/3.0.9/setup/installing/alpine-linux.md
+++ b/content/riak/kv/3.0.9/setup/installing/alpine-linux.md
@@ -15,15 +15,15 @@ since: 3.0.9
 version_history:
   in: "3.0.9+"
 aliases:
-  - /riak/3.0.10/ops/building/installing/installing-on-alpine-linux
-  - /riak/kv/3.0.10/ops/building/installing/installing-on-alpine-linux
-  - /riak/3.0.10/installing/alpine-linux/
-  - /riak/kv/3.0.10/installing/alpine-linux/
+  - /riak/3.0.9/ops/building/installing/installing-on-alpine-linux
+  - /riak/kv/3.0.9/ops/building/installing/installing-on-alpine-linux
+  - /riak/3.0.9/installing/alpine-linux/
+  - /riak/kv/3.0.9/installing/alpine-linux/
 ---
 
-[security index]: {{<baseurl>}}riak/kv/3.0.10/using/security/
-[install source erlang]: {{<baseurl>}}riak/kv/3.0.10/setup/installing/source/erlang
-[install verify]: {{<baseurl>}}riak/kv/3.0.10/setup/installing/verify
+[security index]: {{<baseurl>}}riak/kv/3.0.9/using/security/
+[install source erlang]: {{<baseurl>}}riak/kv/3.0.9/setup/installing/source/erlang
+[install verify]: {{<baseurl>}}riak/kv/3.0.9/setup/installing/verify
 
 Riak KV can be installed on Alpine Linux using a binary
 package from the Riak repository.

--- a/content/riak/kv/3.2.0/setup/installing/alpine-linux.md
+++ b/content/riak/kv/3.2.0/setup/installing/alpine-linux.md
@@ -1,0 +1,54 @@
+﻿---
+title_supertext: "Installing on"
+title: "Alpine Linux"
+description: "installing Riak on Alpine Linux"
+project: "riak_kv"
+project_version: 3.2.0
+menu:
+  riak_kv-3.2.0:
+    name: "Alpine Linux"
+    identifier: "installing_alpine_linux"
+    weight: 301
+    parent: "installing"
+since: 3.0.9
+version_history:
+  in: "3.0.9+"
+toc: true
+aliases:
+  - /riak/3.2.0/ops/building/installing/installing-on-alpine-linux
+  - /riak/kv/3.2.0/ops/building/installing/installing-on-alpine-linux
+  - /riak/3.2.0/installing/alpine-linux/
+  - /riak/kv/3.2.0/installing/alpine-linux/
+---
+
+[security index]: {{<baseurl>}}riak/kv/3.2.0/using/security/
+[install source erlang]: {{<baseurl>}}riak/kv/3.2.0/setup/installing/source/erlang
+[install verify]: {{<baseurl>}}riak/kv/3.2.0/setup/installing/verify
+
+Riak KV can be installed on Alpine Linux using a binary
+package from the Riak repository.
+
+The following steps have been tested to work with Riak KV on:
+
+* Alpine Linux 3.16
+* Alpine Linux 3.18
+
+## Riak 64-bit Installation
+
+To install Riak on Alpine Linux:
+
+1. Add the Riak repository:
+   * Run `echo https://files.tiot.jp/alpine/v3.16/main >> /etc/apk/repositories`
+2. Download and install the Riak repository public key:
+   * Run `wget http://files.tiot.jp/alpine/alpine@tiot.jp.rsa.pub -O /etc/apk/keys/alpine@tiot.jp.rsa.pub`
+3. Update your list of packages:
+   * Run `apk update`
+4. Install Riak:
+   * For the latest version, run `apk add riak`
+   * For a version 3.2.0 using OTP 22, run `apk add riak=3.2.0.22-r0`
+   * For a version 3.2.0 using OTP 24, run `apk add riak=3.2.0.24-r0`
+   * For a version 3.2.0 using OTP 25, run `apk add riak=3.2.0.25-r0`
+
+## Next Steps
+
+Now that Riak is installed, check out [Verifying a Riak Installation][install verify].

--- a/content/riak/kv/3.2.0/setup/installing/alpine-linux.md
+++ b/content/riak/kv/3.2.0/setup/installing/alpine-linux.md
@@ -30,8 +30,10 @@ package from the Riak repository.
 
 The following steps have been tested to work with Riak KV on:
 
-* Alpine Linux 3.16
-* Alpine Linux 3.18
+* Alpine Linux 3.16 using x86_64
+* Alpine Linux 3.16 using aarch64
+* Alpine Linux 3.18 using x86_64
+* Alpine Linux 3.18 using aarch64
 
 ## Riak 64-bit Installation
 

--- a/content/riak/kv/3.2.0/setup/installing/alpine-linux.md
+++ b/content/riak/kv/3.2.0/setup/installing/alpine-linux.md
@@ -47,9 +47,9 @@ To install Riak on Alpine Linux:
    * Run `apk update`
 4. Install Riak:
    * For the latest version, run `apk add riak`
-   * For a version 3.2.0 using OTP 22, run `apk add riak=3.2.0.22-r0`
-   * For a version 3.2.0 using OTP 24, run `apk add riak=3.2.0.24-r0`
-   * For a version 3.2.0 using OTP 25, run `apk add riak=3.2.0.25-r0`
+   * For version 3.2.0 using OTP 22, run `apk add riak=3.2.0.22-r0`
+   * For version 3.2.0 using OTP 24, run `apk add riak=3.2.0.24-r0`
+   * For version 3.2.0 using OTP 25, run `apk add riak=3.2.0.25-r0`
 
 ## Next Steps
 

--- a/layouts/_default/downloads.html
+++ b/layouts/_default/downloads.html
@@ -101,7 +101,7 @@
                 </tr>
                 <tr>
                   <td colspan="5" class="downloads__install-instructions">
-                    Installing {{$target_title}} on {{ $alpine_os_title }} uses the <a href="{{$alpine_installing_uri}}">{{ $alpine_os_title }} Riak Repository</a>.
+                    Installing {{$target_title}} on {{ $alpine_os_title }} uses the <a href="{{$alpine_installing_uri}}">{{ $alpine_os_title }} Riak Repository for x86_64 and aarch64 architectures.</a>.
                   </td>
                 </tr>
               </tbody>


### PR DESCRIPTION
- Added missing pages for 3.0.12+
- Updated all to have correct URLs
- Updated 3.0.09-32.0.11 to have -r1 instead of -r0
- Updated downloads template to show x86_64 and aarch64 available
- Updated 3.0.9+ to show Alpine Linux version and architecture