### PR TITLE
Remove general search indexes from sitemap

### DIFF
--- a/content/community/_index.md
+++ b/content/community/_index.md
@@ -3,6 +3,7 @@ outputs:
   - JSON
 layout: list
 exclude_from_search: true
+sitemap_exclude: true
 project: community
 ---
 

--- a/content/riak/cs/_index.md
+++ b/content/riak/cs/_index.md
@@ -3,6 +3,7 @@ outputs:
   - JSON
 layout: list
 exclude_from_search: true
+sitemap_exclude: true
 project: "riak_cs"
 ---
 

--- a/content/riak/kv/_index.md
+++ b/content/riak/kv/_index.md
@@ -3,6 +3,7 @@ outputs:
   - JSON
 layout: list
 exclude_from_search: true
+sitemap_exclude: true
 project: "riak_kv"
 ---
 

--- a/content/riak/ts/_index.md
+++ b/content/riak/ts/_index.md
@@ -3,6 +3,7 @@ outputs:
   - JSON
 layout: list
 exclude_from_search: true
+sitemap_exclude: true
 project: "riak_ts"
 ---
 


### PR DESCRIPTION
Removes project-level and community-level `search-index.json` from the generated sitemap.