### PR TITLE
A few fixes and new content

### DIFF
--- a/content/riak/kv/3.2.0/configuring/next-gen-replication.md
+++ b/content/riak/kv/3.2.0/configuring/next-gen-replication.md
@@ -25,6 +25,7 @@ aliases:
 [configure nextgenrepl realtime]: ./realtime/
 [configure nextgenrepl queuing]: ./queuing/
 [configure nextgenrepl reference]: ./reference/
+[configure nextgenrepl sink]: ./sink/
 [tictacaae folds]: ../../using/tictac-aae-fold/
 
 NextGenRepl provides a considerable improvement over the legacy replication engines. It is faster, more efficient and more reliable. NextGenRepl is the recommended replication engine to use.

--- a/content/riak/kv/3.2.0/configuring/next-gen-replication/fullsync.md
+++ b/content/riak/kv/3.2.0/configuring/next-gen-replication/fullsync.md
@@ -47,14 +47,18 @@ If a source node or sink peer is offline for any reason, Riak will wait until th
 
 The number of different clusters you can FullSync to is defined by the number of Riak KV nodes in the source cluster.
 
+{{% note %}}
+Currently all changes listed in this documentation to NextGenRepl must be made by changing the values in the `riak.conf` file.
+{{% /note %}}
+
 ## Enable
 
 To turn on FullSync replication, a scope of operation (`ttaaefs_scope`) is needed. The default scope is `disabled` which means that FullSync replication is turned off. The scope can be set to:
 
 - `disabled` - FullSync is disabled
 - `all` - all buckets are replicated
-- `bucket` - only the specific bucket is replicated
-- `type` - only buckets of the specific bucket type are replicated
+- `bucket` - only the specified bucket is replicated
+- `type` - only buckets of the specified bucket type are replicated
 
 To FullSync replicate all buckets, use the `ttaaefs_scope` of `any`. For example, to FullSync replicate all buckets, set this value:
 
@@ -88,7 +92,7 @@ ttaaefs_queuename = q1_ttaaefs
 
 ### Bi-directional FullSync
 
-Since Riak KV 3.0.10, it is possible to have the sink cluster also detect changes from the source cluster (bi-directional FullSync) and queue them on the sink clsuter side. This is configured using the `ttaaefs_queuename_peer` setting. The default for this setting is `disabled`.
+From Riak KV 3.0.10 onwards, it is possible to have the sink cluster also detect changes from the source cluster (bi-directional FullSync) and queue them on the sink clsuter side. This is configured using the `ttaaefs_queuename_peer` setting. The default for this setting is `disabled`.
 
 For example, to set the sink cluster FullSync queue name to the standard name of `q1_ttaaefs`, set `ttaaefs_queuename_peer` like this:
 
@@ -147,7 +151,7 @@ repl_key_filename = /etc/riak/key.pem
 
 ### Riak Security
 
-If Riak Security is enabled on the sink cluster, then the username for replication can be set in the `repl_username` setting:
+If Riak Security is enabled on the sink cluster, then the username for replication can be set with the `repl_username` setting:
 
 ```
 repl_username = source-cluster-replication-user

--- a/content/riak/kv/3.2.0/configuring/next-gen-replication/queuing.md
+++ b/content/riak/kv/3.2.0/configuring/next-gen-replication/queuing.md
@@ -44,6 +44,10 @@ The sink side replication manager will connect to its list of replication source
 
 The queuing system is always active.
 
+{{% note %}}
+Currently all changes listed in this documentation to NextGenRepl must be made by changing the values in the `riak.conf` file.
+{{% /note %}}
+
 ## Maximum queue length
 
 The default limit of the number of objects stored in a specific queue is `300000` Riak objects. Once this limit is reached, any new items will not be added to the queue.

--- a/content/riak/kv/3.2.0/configuring/next-gen-replication/realtime.md
+++ b/content/riak/kv/3.2.0/configuring/next-gen-replication/realtime.md
@@ -40,6 +40,10 @@ As changes occur on the source cluster, NextGenRepl's RealTime replication syste
 
 A source node can be the source for multiple sink clusters by using multiple queues. 
 
+{{% note %}}
+Currently all changes listed in this documentation to NextGenRepl must be made by changing the values in the `riak.conf` file.
+{{% /note %}}
+
 ## Enable RealTime
 
 RealTime changes are added to the queuing system by setting:

--- a/content/riak/kv/3.2.0/configuring/next-gen-replication/reference.md
+++ b/content/riak/kv/3.2.0/configuring/next-gen-replication/reference.md
@@ -126,7 +126,7 @@ Setting | Options | Default | Description
 `ttaaefs_nocheck` | `any` (integer) | `0` | How many times per 24hour period should no data be checked to confirm it is fully sync'd. Use nochecks to align the number of checks done by each node - if each node has the same number of slots, they will naurally space their checks within the period of the slot.
 `ttaaefs_hourcheck` | `any` (integer) | `0` | How many times per 24hour period should the last hours data be checked to confirm it is fully sync'd.
 `ttaaefs_daycheck` | `any` (integer) | `0` | How many times per 24hour period should the last 24-hours of data be checked to confirm it is fully sync'd.
-`ttaaefs_rangecheck` | `any` (integer) | `0` | How many times per 24hour period should the a range_check be run.
+`ttaaefs_rangecheck` | `any` (integer) | `0` | How many times per 24hour period should the range_check be run.
 `ttaaefs_logrepairs` | `enabled`, `disabled` | `enabled` | If Tictac AAE full-sync discovers keys to be repaired, should each key that is repaired be logged
 
 ## Sink cluster

--- a/content/riak/kv/3.2.0/configuring/next-gen-replication/sink.md
+++ b/content/riak/kv/3.2.0/configuring/next-gen-replication/sink.md
@@ -38,6 +38,10 @@ NextGenRepl relies on [TicTac AAE](../../active-anti-entropy/tictac-aae/), so th
 
 Sink nodes pull changes from the [Queuing System][configure nextgenrepl queuing] on the source nodes. This will handle both FullSync and RealTime replication as configured on the source nodes.
 
+{{% note %}}
+Currently all changes listed in this documentation to NextGenRepl must be made by changing the values in the `riak.conf` file.
+{{% /note %}}
+
 ## Enable sink
 
 RealTime, FullSync and AAE fold changes will be pulled as part of the NextGenRepl sink process. This is the same process for all NextGenRepl replication types.


### PR DESCRIPTION
Fixed a typo, changed the phrasing in `fullsync.md` from "specific bucket" to "specified"

Added a note on each page to remind the reader that currently, all changes to NextGenRepl/TTAAE must be made via riak.conf